### PR TITLE
asyncio is part of stdlib since Python 3.4

### DIFF
--- a/Rule34-API-Wrapper/setup.py
+++ b/Rule34-API-Wrapper/setup.py
@@ -35,7 +35,7 @@ setup(
     keywords='rule34, porn, api, wrapper',
     project_urls={'Source': 'https://github.com/LordOfPolls/Rule34-API-Wrapper'},
     packages=find_packages(include=['rule34']),
-    install_requires=['asyncio', 'aiohttp'],
+    install_requires=['aiohttp'],
     python_requires='>=3.5',
     py_modules=["rule34"]
 )


### PR DESCRIPTION
It's simply not necessary to install `asyncio` from PyPI. That version was a backport for Python 3.3 (which is EOL) and hasn't been updated since 2015.